### PR TITLE
Make `in` work

### DIFF
--- a/ddbc/cache.py
+++ b/ddbc/cache.py
@@ -22,6 +22,9 @@ class Client(object):
         self.default_ttl = default_ttl
         self.report_error = report_error
 
+    def __contains__(self, key):
+        return self.get(key) is not None
+
     def __getitem__(self, key):
         return self.get(key)
 

--- a/test-deps.txt
+++ b/test-deps.txt
@@ -1,0 +1,3 @@
+nose
+mock
+flake8

--- a/tests/ddbc/cache_test.py
+++ b/tests/ddbc/cache_test.py
@@ -35,6 +35,19 @@ class ClientTestCase(TestCase):
             return_value={'data': 'qux', 'until': -1})
         eq_(client.get('foo'), 'qux')
 
+    def test_key_in_cache(self):
+        client = Client(table_name='foo')
+        client._is_available_item = Mock(return_value=True)
+        client.table.get_item = Mock(
+                return_value={'Item': {'data': 'qux', 'until': -1}})
+        eq_('foo' in client, True)
+
+    def test_key_not_in_cache(self):
+        client = Client(table_name='foo')
+        client._is_available_item = Mock(return_value=False)
+        client.table.get_item = Mock(return_value={})
+        eq_('foo' in client, False)
+
     @raises(botocore.exceptions.ClientError)
     def test_get_error(self):
         client = Client(table_name='foo')

--- a/tox.ini
+++ b/tox.ini
@@ -1,1 +1,12 @@
-[flake8]
+[tox]
+minversion = 1.6
+#envlist = py27,py36,flake8
+envlist = py27,flake8
+
+[testenv]
+deps =
+  -rtest-deps.txt
+commands = nosetests []
+
+[testenv:flake8]
+commands = python setup.py flake8


### PR DESCRIPTION
* Improve automated test suite so that `tox` does the right thing
* Add test for `key in cache` idiom
* Add `__contains__` method so that `key in cache` works.