### PR TITLE
Ensure that `cache` is not shared between Cache objects

### DIFF
--- a/ddbc/cache.py
+++ b/ddbc/cache.py
@@ -9,7 +9,6 @@ from ddbc.utils import get_table
 
 class Client(object):
 
-    cache = {}
 
     def __init__(
         self,
@@ -18,6 +17,7 @@ class Client(object):
         default_ttl=-1,
         report_error=False
     ):
+        self.cache = {}
         self.table = get_table(table_name, region)
         self.default_ttl = default_ttl
         self.report_error = report_error


### PR DESCRIPTION
Ensure that `cache` is an object variable rather than a class
variable - otherwise creating two cache objects will share their
`cache`.